### PR TITLE
ci: fix project board automation for Dependabot

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -5,7 +5,7 @@ on:
   issues:
     types:
       - opened
-  pull_request:
+  pull_request_target:
     types:
       - opened
 


### PR DESCRIPTION
This PR switches the trigger from `pull_request` to `pull_request_target` to allow Dependabot PRs to access the `PROJECT_PAT` secret.